### PR TITLE
Select links without alt when on empty/background layer, remove recent glib-dev dependency, support links to pages in the same document

### DIFF
--- a/src/control/ScrollHandler.cpp
+++ b/src/control/ScrollHandler.cpp
@@ -2,7 +2,9 @@
 
 #include "gui/Layout.h"
 #include "gui/XournalView.h"
+#include "gui/sidebar/Sidebar.h"
 #include "gui/widgets/SpinPageAdapter.h"
+#include "model/LinkDestination.h"
 
 #include "Control.h"
 
@@ -66,6 +68,30 @@ void ScrollHandler::scrollToSpinPage() {
         return;
     }
     scrollToPage(page - 1);
+}
+
+void ScrollHandler::scrollToLinkDest(const LinkDestination& dest) {
+    size_t pdfPage = dest.getPdfPage();
+    Sidebar* sidebar = control->getSidebar();
+
+    if (pdfPage != npos) {
+        Document* doc = control->getDocument();
+        doc->lock();
+        size_t page = doc->findPdfPage(pdfPage);
+        doc->unlock();
+
+        if (page == npos) {
+            sidebar->askInsertPdfPage(pdfPage);
+        } else {
+            if (dest.shouldChangeTop()) {
+                control->getScrollHandler()->scrollToPage(page, dest.getTop() * control->getZoomControl()->getZoom());
+            } else {
+                if (control->getCurrentPageNo() != page) {
+                    control->getScrollHandler()->scrollToPage(page);
+                }
+            }
+        }
+    }
 }
 
 void ScrollHandler::scrollToAnnotatedPage(bool next) {

--- a/src/control/ScrollHandler.h
+++ b/src/control/ScrollHandler.h
@@ -23,6 +23,7 @@
 
 class XojPage;
 class Control;
+class LinkDestination;
 
 class ScrollHandler: public SpinPageListener {
 public:
@@ -40,6 +41,17 @@ public:
     void scrollToPage(size_t page, double top = 0);
 
     void scrollToAnnotatedPage(bool next);
+
+    /**
+     * Scroll to a given link's destination, provided the
+     * destination is a local destination and not a URI.
+     *
+     *  If the destination is a non-existent PDF page,
+     * we ask the user whether to add the missing page or not.
+     *
+     * @param dest is to shown
+     */
+    void scrollToLinkDest(const LinkDestination& dest);
 
     bool isPageVisible(size_t page, int* visibleHeight = nullptr);
 

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -3,7 +3,9 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <iomanip>
 #include <memory>
+#include <tuple>
 
 #include <gdk/gdk.h>
 #include <glib/gprintf.h>
@@ -27,9 +29,11 @@
 #include "control/tools/VerticalToolHandler.h"
 #include "model/Image.h"
 #include "model/Layer.h"
+#include "model/LinkDestination.h"
 #include "model/PageRef.h"
 #include "model/Stroke.h"
 #include "model/Text.h"
+#include "pdf/base/XojPdfAction.h"
 #include "undo/DeleteUndoAction.h"
 #include "undo/InsertUndoAction.h"
 #include "undo/TextBoxUndoAction.h"
@@ -127,7 +131,7 @@ auto XojPageView::searchTextOnPage(string& text, int* occures, double* top) -> b
             return true;
         }
 
-        int pNr = this->page->getPdfPageNr();
+        size_t pNr = this->page->getPdfPageNr();
         XojPdfPageSPtr pdf = nullptr;
         if (pNr != -1) {
             Document* doc = xournal->getControl()->getDocument();
@@ -157,7 +161,7 @@ void XojPageView::endText() {
     // Text deleted
     if (txt->getText().empty()) {
         // old element
-        int pos = layer->indexOf(txt);
+        Layer::ElementIndex pos = layer->indexOf(txt);
         if (pos != -1) {
             auto eraseDeleteUndoAction = std::make_unique<DeleteUndoAction>(page, true);
             layer->removeElement(txt, false);
@@ -361,8 +365,8 @@ auto XojPageView::onButtonPressEvent(const PositionInputData& pos) -> bool {
         GtkWidget* widget = xournal->getWidget();
         gtk_widget_translate_coordinates(widget, gtk_widget_get_toplevel(widget), 0, 0, &wx, &wy);
 
-        wx += std::lround(pos.x) + this->getX();
-        wy += std::lround(pos.y) + this->getY();
+        wx += static_cast<int>(std::lround(pos.x) + this->getX());
+        wy += static_cast<int>(std::lround(pos.y) + this->getY());
 
         control->getWindow()->floatingToolbox->show(wx, wy);
     }
@@ -546,47 +550,22 @@ auto XojPageView::onButtonReleaseEvent(const PositionInputData& pos) -> bool {
         } else {
             double zoom = xournal->getZoom();
             if (this->selection->userTapped(zoom)) {
-                if (pos.isAltDown()) {
+                Layer* layer = this->page->getSelectedLayer();
+                int layerId = this->page->getSelectedLayerId();
+                bool isBackgroundLayer = (layerId == 0);
+
+                // If there's nothing to select (e.g. the background layer)
+                // or we're holding alt...
+                if (isBackgroundLayer || !layer->isAnnotated() || pos.isAltDown()) {
                     // Attempt PDF selection
                     auto& pdfDoc = this->xournal->getDocument()->getPdfDocument();
                     if (this->getPage()->getPdfPageNr() != npos) {
                         auto page = pdfDoc.getPage(this->getPage()->getPdfPageNr());
 
-                        // Search for selected link
-                        const auto links = page->getLinks();
-                        for (auto&& [rect, uri]: links) {
-                            const double pageX = pos.x / zoom;
-                            const double pageY = pos.y / zoom;
-                            if (!(rect.x1 <= pageX && pageX <= rect.x2 && rect.y1 <= pageY && pageY <= rect.y2)) {
-                                continue;
-                            }
+                        const double pageX = pos.x / zoom;
+                        const double pageY = pos.y / zoom;
 
-                            char* uriStr = g_uri_to_string(uri);
-                            char* uriText = g_markup_escape_text(uriStr, -1);
-                            char* labelMarkup = g_strdup_printf("<a href=\"%s\">%s</a>", uriStr, uriText);
-                            g_free(uriStr);
-                            g_free(uriText);
-                            GtkWidget* label = gtk_label_new(nullptr);
-                            gtk_label_set_markup(GTK_LABEL(label), labelMarkup);
-
-                            GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-                            gtk_container_add(GTK_CONTAINER(box), label);
-                            gtk_widget_show_all(box);
-
-                            GtkWidget* popover = gtk_popover_new(this->getXournal()->getWidget());
-                            gtk_container_add(GTK_CONTAINER(popover), box);
-
-                            auto x = static_cast<int>(this->getX() + rect.x1 * zoom);
-                            auto y = static_cast<int>(this->getY() + rect.y1 * zoom);
-                            auto w = static_cast<int>((rect.x2 - rect.x1) * zoom);
-                            auto h = static_cast<int>((rect.y2 - rect.y1) * zoom);
-                            GdkRectangle canvasRect{x, y, w, h};
-                            gtk_popover_set_pointing_to(GTK_POPOVER(popover), &canvasRect);
-                            gtk_popover_set_constrain_to(GTK_POPOVER(popover), GTK_POPOVER_CONSTRAINT_WINDOW);
-                            gtk_popover_popup(GTK_POPOVER(popover));
-
-                            break;
-                        }
+                        displayLinkPopover(page, pageX, pageY);
                     }
                 } else {
                     SelectObject select(this);
@@ -765,6 +744,91 @@ void XojPageView::drawLoadingPage(cairo_t* cr) {
     cairo_show_text(cr, txtLoading.c_str());
 
     rerenderPage();
+}
+
+bool XojPageView::displayLinkPopover(std::shared_ptr<XojPdfPage> page, double pageX, double pageY) {
+    // Search for selected link
+    const auto links = page->getLinks();
+
+    for (auto&& [rect, action]: links) {
+        std::shared_ptr<const LinkDestination> dest = action->getDestination();
+
+        if (!(rect.x1 <= pageX && pageX <= rect.x2 && rect.y1 <= pageY && pageY <= rect.y2)) {
+            continue;
+        }
+
+        GtkWidget* box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+        GtkWidget* popover = makePopover(rect, box);
+
+        if (dest->isURI()) {
+            std::string uri = dest->getURI();
+            char* uriLabel = g_markup_escape_text(uri.c_str(), -1);
+
+            std::stringstream labelMarkup;
+            labelMarkup << "<a href=" << std::quoted(uri) << ">";
+            labelMarkup << uriLabel;
+            labelMarkup << "</a>";
+
+            std::string linkMarkup = labelMarkup.str();
+
+            g_free(uriLabel);
+
+            GtkWidget* label = gtk_label_new(nullptr);
+            gtk_label_set_markup(GTK_LABEL(label), linkMarkup.c_str());
+            gtk_container_add(GTK_CONTAINER(box), label);
+        } else {
+            size_t pdfPage = dest->getPdfPage();
+
+            Document* doc = xournal->getControl()->getDocument();
+            doc->lock();
+            size_t pageId = doc->findPdfPage(pdfPage);
+            doc->unlock();
+
+            GtkWidget* button = gtk_button_new_with_label(FC(_F("Scroll to page {1}") % pageId));
+            gtk_container_add(GTK_CONTAINER(box), button);
+
+            g_signal_connect(
+                    button, "clicked",
+                    G_CALLBACK(+[](GtkButton* bt,
+                                   std::tuple<XojPageView*, std::shared_ptr<LinkDestination>, GtkWidget*>* state) {
+                        XojPageView* self;
+                        std::shared_ptr<LinkDestination> dest;
+                        GtkWidget* popover;
+                        std::tie(self, dest, popover) = *state;
+
+                        self->getXournal()->getControl()->getScrollHandler()->scrollToLinkDest(*dest);
+                        gtk_popover_popdown(GTK_POPOVER(popover));
+
+                        free(state);
+                    }),
+                    new std::tuple(this, dest, popover));
+        }
+
+        gtk_widget_show_all(box);
+
+        return true;
+    }
+
+    return false;
+}
+
+GtkWidget* XojPageView::makePopover(const XojPdfRectangle& rect, GtkWidget* child) {
+    double zoom = xournal->getZoom();
+
+    GtkWidget* popover = gtk_popover_new(this->getXournal()->getWidget());
+    gtk_container_add(GTK_CONTAINER(popover), child);
+
+    auto x = static_cast<int>(this->getX() + rect.x1 * zoom);
+    auto y = static_cast<int>(this->getY() + rect.y1 * zoom);
+    auto w = static_cast<int>((rect.x2 - rect.x1) * zoom);
+    auto h = static_cast<int>((rect.y2 - rect.y1) * zoom);
+
+    GdkRectangle canvasRect{x, y, w, h};
+    gtk_popover_set_pointing_to(GTK_POPOVER(popover), &canvasRect);
+    gtk_popover_set_constrain_to(GTK_POPOVER(popover), GTK_POPOVER_CONSTRAINT_WINDOW);
+    gtk_popover_popup(GTK_POPOVER(popover));
+
+    return popover;
 }
 
 /**

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -784,7 +784,12 @@ bool XojPageView::displayLinkPopover(std::shared_ptr<XojPdfPage> page, double pa
             size_t pageId = doc->findPdfPage(pdfPage);
             doc->unlock();
 
-            GtkWidget* button = gtk_button_new_with_label(FC(_F("Scroll to page {1}") % (pageId + 1)));
+            GtkWidget* button;
+            if (pageId + 1 > 0) {
+                button = gtk_button_new_with_label(FC(_F("Scroll to page {1}") % (pageId + 1)));
+            } else {
+                button = gtk_button_new_with_label(FC(_F("Add missing page")));
+            }
             gtk_container_add(GTK_CONTAINER(box), button);
 
             g_signal_connect(

--- a/src/gui/PageView.cpp
+++ b/src/gui/PageView.cpp
@@ -784,7 +784,7 @@ bool XojPageView::displayLinkPopover(std::shared_ptr<XojPdfPage> page, double pa
             size_t pageId = doc->findPdfPage(pdfPage);
             doc->unlock();
 
-            GtkWidget* button = gtk_button_new_with_label(FC(_F("Scroll to page {1}") % pageId));
+            GtkWidget* button = gtk_button_new_with_label(FC(_F("Scroll to page {1}") % (pageId + 1)));
             gtk_container_add(GTK_CONTAINER(box), button);
 
             g_signal_connect(

--- a/src/gui/PageView.h
+++ b/src/gui/PageView.h
@@ -31,6 +31,8 @@ class Text;
 class TextEditor;
 class VerticalToolHandler;
 class XournalView;
+class XojPdfRectangle;
+class XojPdfPage;
 
 class XojPageView: public Redrawable, public PageListener {
 public:
@@ -176,6 +178,26 @@ private:
 
     void drawLoadingPage(cairo_t* cr);
 
+    /**
+     * @brief Make and display a popover dialog near the given location.
+     *
+     * @param rect specifies the location of the dialog.
+     * @param child is added to the dialog before displaying.
+     * @returns a pointer to the popover dialog.
+     */
+    GtkWidget* makePopover(const XojPdfRectangle& rect, GtkWidget* child);
+
+    /**
+     * @brief Display a popover with link-related actions, if one
+     *  is at a given location on the page.
+     *
+     * @param page is the current page
+     * @param targetX
+     * @param targetY the link must contain (targetX, targetY)
+     * @returns true iff a URI link exists near/at (targetX, targetY) => a popover was shown
+     */
+    bool displayLinkPopover(std::shared_ptr<XojPdfPage> page, double targetX, double targetY);
+
     void setX(int x);
     void setY(int y);
 
@@ -223,7 +245,7 @@ private:
     /**
      * Unixtimestam when the page was last time in the visible area
      */
-    int lastVisibleTime = -1;
+    long int lastVisibleTime = -1;
 
     GMutex repaintRectMutex{};
     vector<Rectangle<double>> rerenderRects;

--- a/src/gui/sidebar/Sidebar.cpp
+++ b/src/gui/sidebar/Sidebar.cpp
@@ -1,6 +1,7 @@
 #include "Sidebar.h"
 
 #include <config-features.h>
+#include <gtk/gtk.h>
 
 #include "control/Control.h"
 #include "control/PdfCache.h"
@@ -10,6 +11,7 @@
 #include "model/XojPage.h"
 #include "previews/layer/SidebarPreviewLayers.h"
 #include "previews/page/SidebarPreviewPages.h"
+#include "util/i18n.h"
 
 Sidebar::Sidebar(GladeGui* gui, Control* control): toolbar(this, gui), control(control), gui(gui) {
     this->tbSelectPage = GTK_TOOLBAR(gui->get("tbSelectSidebarPage"));
@@ -64,6 +66,47 @@ void Sidebar::buttonClicked(GtkToolButton* toolbutton, SidebarPageButton* button
 }
 
 void Sidebar::addPage(AbstractSidebarPage* page) { this->pages.push_back(page); }
+
+void Sidebar::askInsertPdfPage(size_t pdfPage) {
+    GtkWidget* dialog = gtk_message_dialog_new(control->getGtkWindow(), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION,
+                                               GTK_BUTTONS_NONE, "%s",
+                                               FC(_F("Your current document does not contain PDF Page no {1}\n"
+                                                     "Would you like to insert this page?\n\n"
+                                                     "Tip: You can select Journal → Paper Background → PDF Background "
+                                                     "to insert a PDF page.") %
+                                                  (pdfPage + 1)));
+
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "Cancel", 1);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "Insert after", 2);
+    gtk_dialog_add_button(GTK_DIALOG(dialog), "Insert at end", 3);
+
+    gtk_window_set_transient_for(GTK_WINDOW(dialog), control->getGtkWindow());
+    int res = gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+    if (res == 1) {
+        return;
+    }
+
+    int position = 0;
+
+    Document* doc = control->getDocument();
+
+    if (res == 2) {
+        position = control->getCurrentPageNo() + 1;
+    } else if (res == 3) {
+        position = doc->getPageCount();
+    }
+
+    doc->lock();
+    XojPdfPageSPtr pdf = doc->getPdfPage(pdfPage);
+    doc->unlock();
+
+    if (pdf) {
+        auto page = std::make_shared<XojPage>(pdf->getWidth(), pdf->getHeight());
+        page->setBackgroundPdfPageNr(pdfPage);
+        control->insertPage(std::move(page), position);
+    }
+}
 
 Sidebar::~Sidebar() {
     this->control = nullptr;

--- a/src/gui/sidebar/Sidebar.h
+++ b/src/gui/sidebar/Sidebar.h
@@ -73,6 +73,12 @@ public:
      */
     SidebarToolbar* getToolbar();
 
+    /**
+     * Ask the user whether a page with the given id
+     * should be added to the document.
+     */
+    void askInsertPdfPage(size_t pdfPage);
+
 public:
     // DocumentListener interface
     virtual void documentChanged(DocumentChangeType type);

--- a/src/gui/sidebar/indextree/SidebarIndexPage.cpp
+++ b/src/gui/sidebar/indextree/SidebarIndexPage.cpp
@@ -71,47 +71,6 @@ void SidebarIndexPage::disableSidebar() {
     // Nothing to do at the moment
 }
 
-void SidebarIndexPage::askInsertPdfPage(size_t pdfPage) {
-    GtkWidget* dialog = gtk_message_dialog_new(control->getGtkWindow(), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION,
-                                               GTK_BUTTONS_NONE, "%s",
-                                               FC(_F("Your current document does not contain PDF Page no {1}\n"
-                                                     "Would you like to insert this page?\n\n"
-                                                     "Tip: You can select Journal → Paper Background → PDF Background "
-                                                     "to insert a PDF page.") %
-                                                  (pdfPage + 1)));
-
-    gtk_dialog_add_button(GTK_DIALOG(dialog), "Cancel", 1);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), "Insert after", 2);
-    gtk_dialog_add_button(GTK_DIALOG(dialog), "Insert at end", 3);
-
-    gtk_window_set_transient_for(GTK_WINDOW(dialog), control->getGtkWindow());
-    int res = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-    if (res == 1) {
-        return;
-    }
-
-    int position = 0;
-
-    Document* doc = control->getDocument();
-
-    if (res == 2) {
-        position = control->getCurrentPageNo() + 1;
-    } else if (res == 3) {
-        position = doc->getPageCount();
-    }
-
-    doc->lock();
-    XojPdfPageSPtr pdf = doc->getPdfPage(pdfPage);
-    doc->unlock();
-
-    if (pdf) {
-        auto page = std::make_shared<XojPage>(pdf->getWidth(), pdf->getHeight());
-        page->setBackgroundPdfPageNr(pdfPage);
-        control->insertPage(std::move(page), position);
-    }
-}
-
 auto SidebarIndexPage::treeBookmarkSelected(GtkWidget* treeview, SidebarIndexPage* sidebar) -> bool {
     if (sidebar->searchTimeout) {
         return false;
@@ -132,27 +91,7 @@ auto SidebarIndexPage::treeBookmarkSelected(GtkWidget* treeview, SidebarIndexPag
             if (link && link->dest) {
                 LinkDestination* dest = link->dest;
 
-                size_t pdfPage = dest->getPdfPage();
-
-                if (pdfPage != npos) {
-                    Document* doc = sidebar->control->getDocument();
-                    doc->lock();
-                    size_t page = doc->findPdfPage(pdfPage);
-                    doc->unlock();
-
-                    if (page == npos) {
-                        sidebar->askInsertPdfPage(pdfPage);
-                    } else {
-                        if (dest->shouldChangeTop()) {
-                            sidebar->control->getScrollHandler()->scrollToPage(
-                                    page, dest->getTop() * sidebar->control->getZoomControl()->getZoom());
-                        } else {
-                            if (sidebar->control->getCurrentPageNo() != page) {
-                                sidebar->control->getScrollHandler()->scrollToPage(page);
-                            }
-                        }
-                    }
-                }
+                sidebar->control->getScrollHandler()->scrollToLinkDest(*dest);
             }
             g_object_unref(link);
 

--- a/src/gui/sidebar/indextree/SidebarIndexPage.h
+++ b/src/gui/sidebar/indextree/SidebarIndexPage.h
@@ -79,11 +79,6 @@ private:
     static bool treeBookmarkSelected(GtkWidget* treeview, SidebarIndexPage* sidebar);
 
     /**
-     * If you select a Bookmark which is currently not in the Xournal document, only in the PDF (page deleted or so)
-     */
-    void askInsertPdfPage(size_t pdfPage);
-
-    /**
      * The function which is called after a search timeout
      */
     static bool searchTimeoutFunc(SidebarIndexPage* sidebar);

--- a/src/model/Document.cpp
+++ b/src/model/Document.cpp
@@ -188,7 +188,9 @@ void Document::buildTreeContentsModel(GtkTreeIter* parent, XojPdfBookmarkIterato
         GtkTreeIter treeIter = {0};
 
         XojPdfAction* action = iter->getAction();
-        XojLinkDest* link = action->getDestination();
+        LinkDestination* dest = new LinkDestination(*action->getDestination());
+        XojLinkDest* link = link_dest_new();
+        link->dest = dest;
 
         if (action->getTitle().empty()) {
             g_object_unref(link);

--- a/src/model/LinkDestination.cpp
+++ b/src/model/LinkDestination.cpp
@@ -36,52 +36,60 @@ static void link_dest_class_init(XojLinkDestClass* linkClass) {
 
 auto link_dest_new() -> XojLinkDest* { return LINK_DEST(g_object_new(TYPE_LINK_DEST, nullptr)); }
 
-LinkDestination::LinkDestination() {
-    this->page = npos;
-    this->changeLeft = false;
-    this->changeZoom = false;
-    this->changeTop = false;
-    this->zoom = 0;
-    this->left = 0;
-    this->top = 0;
-    this->expand = false;
-}
+LinkDestination::LinkDestination():
+        _page(npos),
+        _changeLeft(false),
+        _changeZoom(false),
+        _changeTop(false),
+        _zoom(0),
+        _left(0),
+        _top(0),
+        _expand(false),
+        _isURI(false),
+        _name(""),
+        _uri("") {}
 
 LinkDestination::~LinkDestination() = default;
 
-auto LinkDestination::getPdfPage() const -> size_t { return this->page; }
+auto LinkDestination::getPdfPage() const -> size_t { return _page; }
 
-void LinkDestination::setPdfPage(size_t page) { this->page = page; }
+void LinkDestination::setPdfPage(size_t page) { _page = page; }
 
-void LinkDestination::setExpand(bool expand) { this->expand = expand; }
+void LinkDestination::setExpand(bool expand) { _expand = expand; }
 
-auto LinkDestination::getExpand() const -> bool { return this->expand; }
+auto LinkDestination::getExpand() const -> bool { return _expand; }
 
-auto LinkDestination::shouldChangeLeft() const -> bool { return changeLeft; }
+auto LinkDestination::shouldChangeLeft() const -> bool { return _changeLeft; }
 
-auto LinkDestination::shouldChangeTop() const -> bool { return changeTop; }
+auto LinkDestination::shouldChangeTop() const -> bool { return _changeTop; }
 
-auto LinkDestination::getZoom() const -> double { return zoom; }
+auto LinkDestination::getZoom() const -> double { return _zoom; }
 
-auto LinkDestination::getLeft() const -> double { return left; }
+auto LinkDestination::getLeft() const -> double { return _left; }
 
-auto LinkDestination::getTop() const -> double { return top; }
+auto LinkDestination::getTop() const -> double { return _top; }
 
 void LinkDestination::setChangeLeft(double left) {
-    this->left = left;
-    this->changeLeft = true;
+    _left = left;
+    _changeLeft = true;
 }
 
 void LinkDestination::setChangeZoom(double zoom) {
-    this->zoom = zoom;
-    this->changeZoom = true;
+    _zoom = zoom;
+    _changeZoom = true;
 }
 
 void LinkDestination::setChangeTop(double top) {
-    this->top = top;
-    this->changeTop = true;
+    _top = top;
+    _changeTop = true;
 }
 
-void LinkDestination::setName(string name) { this->name = std::move(name); }
+void LinkDestination::setName(string name) { _name = std::move(name); }
+auto LinkDestination::getName() -> string { return _name; }
 
-auto LinkDestination::getName() -> string { return this->name; }
+void LinkDestination::setURI(string uri) {
+    _uri = std::move(uri);
+    _isURI = true;
+}
+auto LinkDestination::getURI() const -> string { return _uri; }
+bool LinkDestination::isURI() const { return _isURI; }

--- a/src/model/LinkDestination.h
+++ b/src/model/LinkDestination.h
@@ -47,19 +47,25 @@ public:
     void setName(string name);
     string getName();
 
+    bool isURI() const;
+    string getURI() const;
+    void setURI(string uri);
+
 private:
-    size_t page;
-    bool expand;
+    size_t _page;
 
-    double left;
-    double top;
-    double zoom;
+    bool _changeLeft;
+    bool _changeZoom;
+    bool _changeTop;
 
-    bool changeLeft;
-    bool changeZoom;
-    bool changeTop;
+    double _zoom;
+    double _left;
+    double _top;
 
-    string name;
+    bool _expand;
+    bool _isURI;
+
+    string _name, _uri;
 };
 
 struct _LinkDest {

--- a/src/pdf/base/XojPdfAction.h
+++ b/src/pdf/base/XojPdfAction.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -24,7 +25,7 @@ public:
     virtual ~XojPdfAction();
 
 public:
-    virtual XojLinkDest* getDestination() = 0;
+    virtual std::shared_ptr<const LinkDestination> getDestination() = 0;
     virtual string getTitle() = 0;
 
 private:

--- a/src/pdf/base/XojPdfDocument.h
+++ b/src/pdf/base/XojPdfDocument.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -30,18 +31,19 @@ public:
 public:
     XojPdfDocument& operator=(const XojPdfDocument& doc);
     bool operator==(XojPdfDocument& doc);
-    void assign(XojPdfDocumentInterface* doc);
-    bool equals(XojPdfDocumentInterface* doc);
+    void assign(XojPdfDocumentInterface* doc) override;
+    bool equals(XojPdfDocumentInterface* doc) override;
 
 public:
-    bool save(fs::path const& file, GError** error);
-    bool load(fs::path const& file, string password, GError** error);
-    bool load(gpointer data, gsize length, string password, GError** error);
-    bool isLoaded();
+    bool save(fs::path const& file, GError** error) override;
+    bool load(fs::path const& file, string password, GError** error) override;
+    bool load(gpointer data, gsize length, string password, GError** error) override;
+    bool isLoaded() override;
 
-    XojPdfPageSPtr getPage(size_t page);
-    size_t getPageCount();
-    XojPdfBookmarkIterator* getContentsIter();
+    XojPdfPageSPtr getPage(size_t page) override;
+
+    size_t getPageCount() override;
+    XojPdfBookmarkIterator* getContentsIter() override;
 
 private:
     XojPdfDocumentInterface* doc;

--- a/src/pdf/base/XojPdfDocumentInterface.h
+++ b/src/pdf/base/XojPdfDocumentInterface.h
@@ -35,6 +35,7 @@ public:
     virtual bool isLoaded() = 0;
 
     virtual XojPdfPageSPtr getPage(size_t page) = 0;
+
     virtual size_t getPageCount() = 0;
     virtual XojPdfBookmarkIterator* getContentsIter() = 0;
 

--- a/src/pdf/base/XojPdfPage.h
+++ b/src/pdf/base/XojPdfPage.h
@@ -17,7 +17,10 @@
 
 #include <cairo/cairo.h>
 
+#include "XojPdfAction.h"
 #include "XournalType.h"
+
+class XojPdfLink;
 
 
 class XojPdfRectangle {
@@ -37,11 +40,11 @@ public:
     XojPdfPage();
     virtual ~XojPdfPage();
 
-    using Link = std::pair<XojPdfRectangle, GUri*>;
+    using Link = std::pair<XojPdfRectangle, std::unique_ptr<XojPdfAction>>;
 
 public:
-    virtual double getWidth() = 0;
-    virtual double getHeight() = 0;
+    virtual double getWidth() const = 0;
+    virtual double getHeight() const = 0;
 
     virtual void render(cairo_t* cr, bool forPrinting = false) = 0;
 

--- a/src/pdf/base/XojPdfPage.h
+++ b/src/pdf/base/XojPdfPage.h
@@ -37,6 +37,8 @@ public:
     XojPdfPage();
     virtual ~XojPdfPage();
 
+    using Link = std::pair<XojPdfRectangle, GUri*>;
+
 public:
     virtual double getWidth() = 0;
     virtual double getHeight() = 0;
@@ -44,6 +46,8 @@ public:
     virtual void render(cairo_t* cr, bool forPrinting = false) = 0;
 
     virtual vector<XojPdfRectangle> findText(string& text) = 0;
+
+    virtual auto getLinks() -> std::vector<Link> = 0;
 
     virtual int getPageId() = 0;
 

--- a/src/pdf/popplerapi/PopplerGlibAction.cpp
+++ b/src/pdf/popplerapi/PopplerGlibAction.cpp
@@ -1,27 +1,32 @@
 #include "PopplerGlibAction.h"
 
-PopplerGlibAction::PopplerGlibAction(PopplerAction* action, PopplerDocument* document):
-        action(action), document(document) {
+PopplerGlibAction::PopplerGlibAction(PopplerAction* action, PopplerDocument* document): document(document) {
     g_object_ref(document);
+
+    gchar* title_cstr = (reinterpret_cast<PopplerActionAny*>(action))->title;
+
+    if (title_cstr != nullptr) {
+        title = std::string{title_cstr};
+    }
+
+    destination = getDestination(action);
 }
 
 PopplerGlibAction::~PopplerGlibAction() {
-    poppler_action_free(action);
-    action = nullptr;
-
     if (document) {
         g_object_unref(document);
         document = nullptr;
     }
 }
 
-auto PopplerGlibAction::getDestination() -> XojLinkDest* {
-    XojLinkDest* dest = link_dest_new();
-    dest->dest = new LinkDestination();
-    dest->dest->setName(getTitle());
+auto PopplerGlibAction::getDestination(PopplerAction* action) -> std::shared_ptr<const LinkDestination> {
+    std::shared_ptr<LinkDestination> dest = std::make_shared<LinkDestination>();
+    dest->setName(getTitle());
 
     // every other action is not supported in Xournal
-    if (action->type == POPPLER_ACTION_GOTO_DEST) {
+    if (action->type == POPPLER_ACTION_URI && action->uri.uri) {
+        dest->setURI(std::string{action->uri.uri});
+    } else if (action->type == POPPLER_ACTION_GOTO_DEST) {
         auto* actionDest = reinterpret_cast<PopplerActionGotoDest*>(action);
         PopplerDest* pDest = actionDest->dest;
 
@@ -29,13 +34,15 @@ auto PopplerGlibAction::getDestination() -> XojLinkDest* {
             return dest;
         }
 
-        linkFromDest(dest->dest, pDest);
+        linkFromDest(*dest, pDest);
     }
 
     return dest;
 }
 
-void PopplerGlibAction::linkFromDest(LinkDestination* link, PopplerDest* pDest) {
+auto PopplerGlibAction::getDestination() -> std::shared_ptr<const LinkDestination> { return destination; }
+
+void PopplerGlibAction::linkFromDest(LinkDestination& link, PopplerDest* pDest) {
     switch (pDest->type) {
         case POPPLER_DEST_UNKNOWN:
             g_warning("PDF Contains unknown link destination");
@@ -51,19 +58,19 @@ void PopplerGlibAction::linkFromDest(LinkDestination* link, PopplerDest* pDest) 
             poppler_page_get_size(page, &pageWidth, &pageHeight);
 
             if (pDest->left) {
-                link->setChangeLeft(pDest->left);
+                link.setChangeLeft(pDest->left);
             } else if (pDest->right) {
-                link->setChangeLeft(pageWidth - pDest->right);
+                link.setChangeLeft(pageWidth - pDest->right);
             }
 
             if (pDest->top) {
-                link->setChangeTop(pageHeight - std::min(pageHeight, pDest->top));
+                link.setChangeTop(pageHeight - std::min(pageHeight, pDest->top));
             } else if (pDest->bottom) {
-                link->setChangeTop(pageHeight - std::min(pageHeight, pageHeight - pDest->bottom));
+                link.setChangeTop(pageHeight - std::min(pageHeight, pageHeight - pDest->bottom));
             }
 
             if (pDest->zoom != 0) {
-                link->setChangeZoom(pDest->zoom);
+                link.setChangeZoom(pDest->zoom);
             }
             g_object_unref(page);
         } break;
@@ -80,7 +87,7 @@ void PopplerGlibAction::linkFromDest(LinkDestination* link, PopplerDest* pDest) 
             break;
     }
 
-    link->setPdfPage(pDest->page_num - 1);
+    link.setPdfPage(pDest->page_num - 1);
 }
 
-auto PopplerGlibAction::getTitle() -> string { return (reinterpret_cast<PopplerActionAny*>(action))->title; }
+auto PopplerGlibAction::getTitle() -> string { return title; }

--- a/src/pdf/popplerapi/PopplerGlibAction.h
+++ b/src/pdf/popplerapi/PopplerGlibAction.h
@@ -11,16 +11,16 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
+
+#include <poppler.h>
 
 #include "model/LinkDestination.h"
 #include "pdf/base/XojPdfAction.h"
 
 #include "XournalType.h"
-using std::string;
-
-#include <poppler.h>
 
 class LinkDestination;
 
@@ -31,13 +31,15 @@ public:
     virtual ~PopplerGlibAction();
 
 public:
-    virtual XojLinkDest* getDestination();
-    virtual string getTitle();
+    virtual std::shared_ptr<const LinkDestination> getDestination() override;
+    virtual std::string getTitle() override;
 
 private:
-    void linkFromDest(LinkDestination* link, PopplerDest* pDest);
+    virtual std::shared_ptr<const LinkDestination> getDestination(PopplerAction* action);
+    void linkFromDest(LinkDestination& link, PopplerDest* pDest);
 
 private:
-    PopplerAction* action;
     PopplerDocument* document;
+    std::shared_ptr<const LinkDestination> destination;
+    std::string title;
 };

--- a/src/pdf/popplerapi/PopplerGlibDocument.cpp
+++ b/src/pdf/popplerapi/PopplerGlibDocument.cpp
@@ -83,8 +83,8 @@ auto PopplerGlibDocument::getPage(size_t page) -> XojPdfPageSPtr {
         return nullptr;
     }
 
-    PopplerPage* pg = poppler_document_get_page(document, page);
-    XojPdfPageSPtr pageptr = std::make_shared<PopplerGlibPage>(pg);
+    PopplerPage* pg = poppler_document_get_page(document, static_cast<int>(page));
+    XojPdfPageSPtr pageptr = std::make_shared<PopplerGlibPage>(pg, document);
     g_object_unref(pg);
 
     return pageptr;

--- a/src/pdf/popplerapi/PopplerGlibDocument.h
+++ b/src/pdf/popplerapi/PopplerGlibDocument.h
@@ -24,18 +24,19 @@ public:
     virtual ~PopplerGlibDocument();
 
 public:
-    virtual void assign(XojPdfDocumentInterface* doc);
-    virtual bool equals(XojPdfDocumentInterface* doc);
+    virtual void assign(XojPdfDocumentInterface* doc) override;
+    virtual bool equals(XojPdfDocumentInterface* doc) override;
 
 public:
-    virtual bool save(fs::path const& filepath, GError** error);
-    virtual bool load(fs::path const& filepath, string password, GError** error);
-    virtual bool load(gpointer data, gsize length, string password, GError** error);
-    virtual bool isLoaded();
+    virtual bool save(fs::path const& filepath, GError** error) override;
+    virtual bool load(fs::path const& filepath, string password, GError** error) override;
+    virtual bool load(gpointer data, gsize length, string password, GError** error) override;
+    virtual bool isLoaded() override;
 
-    virtual XojPdfPageSPtr getPage(size_t page);
-    virtual size_t getPageCount();
-    virtual XojPdfBookmarkIterator* getContentsIter();
+    virtual XojPdfPageSPtr getPage(size_t page) override;
+
+    virtual size_t getPageCount() override;
+    virtual XojPdfBookmarkIterator* getContentsIter() override;
 
 private:
     PopplerDocument* document = nullptr;

--- a/src/pdf/popplerapi/PopplerGlibPage.h
+++ b/src/pdf/popplerapi/PopplerGlibPage.h
@@ -18,23 +18,24 @@
 
 class PopplerGlibPage: public XojPdfPage {
 public:
-    PopplerGlibPage(PopplerPage* page);
+    PopplerGlibPage(PopplerPage* page, PopplerDocument* doc);
     PopplerGlibPage(const PopplerGlibPage& other);
     virtual ~PopplerGlibPage();
     PopplerGlibPage& operator=(const PopplerGlibPage& other);
 
 public:
-    virtual double getWidth();
-    virtual double getHeight();
+    virtual double getWidth() const override;
+    virtual double getHeight() const override;
 
-    virtual void render(cairo_t* cr, bool forPrinting = false);  // NOLINT(google-default-arguments)
+    virtual void render(cairo_t* cr, bool forPrinting = false) override;  // NOLINT(google-default-arguments)
 
-    virtual vector<XojPdfRectangle> findText(string& text);
+    virtual vector<XojPdfRectangle> findText(string& text) override;
 
     auto getLinks() -> std::vector<Link> override;
 
-    virtual int getPageId();
+    virtual int getPageId() override;
 
 private:
     PopplerPage* page;
+    PopplerDocument* document;
 };

--- a/src/pdf/popplerapi/PopplerGlibPage.h
+++ b/src/pdf/popplerapi/PopplerGlibPage.h
@@ -31,6 +31,8 @@ public:
 
     virtual vector<XojPdfRectangle> findText(string& text);
 
+    auto getLinks() -> std::vector<Link> override;
+
     virtual int getPageId();
 
 private:

--- a/src/pdf/popplerapi/PopplerGlibPageBookmarkIterator.cpp
+++ b/src/pdf/popplerapi/PopplerGlibPageBookmarkIterator.cpp
@@ -35,5 +35,8 @@ auto PopplerGlibPageBookmarkIterator::getAction() -> XojPdfAction* {
         return nullptr;
     }
 
-    return new PopplerGlibAction(action, document);
+    XojPdfAction* result = new PopplerGlibAction(action, document);
+    poppler_action_free(action);  // XojPdfAction does not own action.
+
+    return result;
 }

--- a/src/util/CrashHandlerUnix.h
+++ b/src/util/CrashHandlerUnix.h
@@ -84,7 +84,7 @@ static void crashHandler(int sig) {
     fp << FORMAT_STR("Error: signal {1}") % sig;
     fp << "\n";
 
-    messages = backtrace_symbols(array, size);
+    messages = backtrace_symbols(array, static_cast<int>(size));
 
     for (size_t i = 0; i < size; i++) {
         fp << FORMAT_STR("[bt]: ({1}) {2}") % i % messages[i];


### PR DESCRIPTION
## Functionality
 * **Select tool:** In addition to `Alt+Click`, selecting the background layer (or some other empty layer) and clicking on a link with the select tool displays the "follow link" popup.
 * **Linking:** Adds support for local document references.
     * ![local document reference popup displays the page the link points to](https://user-images.githubusercontent.com/46334387/106643406-8c3b3400-653e-11eb-8859-4263f6587e11.png)

## Refactoring
 * Re-defined the `Link` type alias to `std::pair<XojPdfRectangle, std::unique_ptr<XojPdfAction>>`.
 * Added an external URI field to `LinkDestination`, which can be gotten from `XojPdfAction`.
 * `PopplerGlibAction` no longer owns the `PopplerAction` it is given -- this object must be freed by clients.
     * `poppler_page_free_link_mapping(links)` was freeing `PopplerAction`s before `PopplerGlibAction` used them. `PopplerGlibAction` now determines link destinations when constructed.
 * `PopplerGlibPage` stores a reference to its parent document.
    * Used to construct `PopplerGlibAction`s in `getLinks()`.

## Dependency-related changes
 * Functions related to GUri* require a more-recent version of `glib-dev` than is available on many systems. This PR removes this dependency.